### PR TITLE
fix hardcoded paths

### DIFF
--- a/lib/tzdata/data_builder.ex
+++ b/lib/tzdata/data_builder.ex
@@ -5,7 +5,6 @@ defmodule Tzdata.DataBuilder do
 
   # download new data releases, then parse them, build
   # periods and save the data in an ETS table
-  @release_dir Path.join(__DIR__, "../../priv/release_ets")
   def load_and_save_table do
     {:ok, content_length, release_version, tzdata_dir} = DataLoader.download_new
     ets_table_name = ets_table_name_for_release_version(release_version)
@@ -25,9 +24,9 @@ defmodule Tzdata.DataBuilder do
       insert_periods_for_zone(table, map, zone_name)
     end)
     File.rm_rf(tzdata_dir) # remove temporary tzdata dir
-    ets_tmp_file_name = "#{@release_dir}#{release_version}.tmp"
+    ets_tmp_file_name = "#{release_dir}#{release_version}.tmp"
     ets_file_name = ets_file_name_for_release_version(release_version)
-    File.mkdir_p(@release_dir)
+    File.mkdir_p(release_dir)
     # Create file using a .tmp line ending to avoid it being
     # recognized as a complete file before writing to it is complete.
     :ets.tab2file(table, :erlang.binary_to_list(ets_tmp_file_name))
@@ -39,7 +38,7 @@ defmodule Tzdata.DataBuilder do
   defp leap_sec_data(tzdata_dir), do: LeapSecParser.read_file(tzdata_dir)
 
   def ets_file_name_for_release_version(release_version) do
-    "#{@release_dir}/#{release_version}.ets"
+    "#{release_dir}/#{release_version}.ets"
   end
 
   def ets_table_name_for_release_version(release_version) do
@@ -66,5 +65,9 @@ defmodule Tzdata.DataBuilder do
      period.std_off,
      period.zone_abbr,
     }
+  end
+
+  defp release_dir do
+    Application.app_dir(:tzdata, "priv/release_ets")
   end
 end

--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -49,23 +49,22 @@ defmodule Tzdata.DataLoader do
     {tag, size}
   end
 
-  @remote_poll_file_name Path.join(__DIR__, "../../priv/latest_remote_poll.txt")
   def set_latest_remote_poll_date do
     {y, m, d} = current_date_utc
-    File.write(@remote_poll_file_name, "#{y}-#{m}-#{d}")
+    File.write(remote_poll_file_name, "#{y}-#{m}-#{d}")
   end
   def latest_remote_poll_date do
     latest_remote_poll_file_exists? |> do_latest_remote_poll_date
   end
   defp do_latest_remote_poll_date(_file_exists = true) do
-    date = File.stream!(@remote_poll_file_name) |> Enum.to_list |> hd
+    date = File.stream!(remote_poll_file_name) |> Enum.to_list |> hd
     |> String.split("-")
     |> Enum.map(&(Integer.parse(&1)|>elem(0)))
     |> List.to_tuple
     {:ok, date}
   end
   defp do_latest_remote_poll_date(_file_exists = false), do: {:unknown, nil}
-  defp latest_remote_poll_file_exists?, do: File.exists? @remote_poll_file_name
+  defp latest_remote_poll_file_exists?, do: File.exists? remote_poll_file_name
 
   defp current_date_utc, do: :calendar.universal_time |> elem(0)
 
@@ -78,5 +77,9 @@ defmodule Tzdata.DataLoader do
         {:ok, days_today - days_latest}
       _ -> {tag, date}
     end
+  end
+
+  def remote_poll_file_name do
+    Application.app_dir(:tzdata, "priv/latest_remote_poll.txt")
   end
 end

--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -43,7 +43,7 @@ defmodule Tzdata.EtsHolder do
   end
 
   defp load_ets_table(release_name) do
-    file_name = Path.join(__DIR__, "../../priv/release_ets/#{release_name}.ets")
+    file_name = Application.app_dir(:tzdata, "priv/release_ets/#{release_name}.ets")
     {:ok, _table} = :ets.file2tab(String.to_char_list(file_name))
   end
 
@@ -66,9 +66,9 @@ defmodule Tzdata.EtsHolder do
     |> List.last
     |> String.replace ".ets", ""
   end
-  @release_ets_dir Path.join(__DIR__, "../../priv/release_ets")
+
   defp release_files do
-    File.ls!(@release_ets_dir)
+    File.ls!(Application.app_dir(:tzdata, "priv/release_ets"))
     |> Enum.filter(&( Regex.match?(~r/^2\d{3}[a-z]\.ets/, &1) ))
     |> Enum.sort
   end


### PR DESCRIPTION
There is a problem with the current compile-time resolving of `priv` dir. If the release is built in one folder, and then moved to some other location, e.g. through deploy, the application will fail. I've experienced this issue since I build my release in a docker image, and then copy it to another image to a different location.

Generally, I don't think you should rely that release will reside where it's built. Instead, it's better to resolve `priv` path dynamically through `Application.app_dir`.

I added a fix, and can confirm that my problem has disappeared with it :-)