### PR TITLE
A few optimizations and removal of imperative uses of if.

### DIFF
--- a/lib/tzdata/parser.ex
+++ b/lib/tzdata/parser.ex
@@ -136,12 +136,10 @@ defmodule Tzdata.Parser do
   # Converts keys to atoms. Discards "name"
   defp captured_zone_map_clean_up(captured) do
     until = transform_until_datetime(captured["until"])
-    map = %{gmtoff: string_amount_to_secs(captured["gmtoff"]),
-    rules: transform_zone_line_rules(captured["rules"]),
-    format: captured["format"],
-    until: until}
-    # remove until key if it is nil
-    if (map[:until]==nil) do map = Map.delete(map,:until) end
-    map
+    Map.merge %{gmtoff: string_amount_to_secs(captured["gmtoff"]),
+      rules: transform_zone_line_rules(captured["rules"]),
+      format: captured["format"]},
+        # remove until key if it is nil
+        if(until == nil, do: %{}, else: %{until: until})
   end
 end

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -32,15 +32,15 @@ defmodule Tzdata.Util do
   defp _string_amount_to_secs(list) when length(list) == 1 or length(list) == 2 do
     list ++ ["00"] |> _string_amount_to_secs
   end
+  # maybe the hours are negative, so multiply the result by -1
+  defp _string_amount_to_secs([<<?- :: utf8>> <> hours | rest]) when length(rest) == 2 do
+    -1 * _string_amount_to_secs([hours | rest])
+  end
   defp _string_amount_to_secs(list) when length(list) == 3 do
     {hours, ""} = Integer.parse(hd(list))
     {mins, ""} = Integer.parse(list|>Enum.at(1))
     {secs, ""} = Integer.parse(list|>Enum.at(2))
-    # maybe the hours are negative, so use the absolute value in this calculation
-    result = abs(hours)*3600+mins*60+secs
-    # if hours are negative, the whole result should be negative: multiply by -1
-    if Regex.match?(~r/-/, hd(list)), do: result = -1*result
-    result
+    hours*3600+mins*60+secs
   end
 
   @doc """


### PR DESCRIPTION
In Elixir 1.3 imperative uses of if are going to emit warnings, so I wanted to remove those, and maybe optimize the code a little while I was at it. This PR changed 3 things.
- The until key doesn't get added to the map when it is nil in Parser.captured_zone_map_clean_up/1.
- The period map isn't created when until_utc == from in PeriodBuilder.calc_periods_for_year/9.
- The output of Util._string_amount_to_secs/1 is calculated normally and multiplied by -1 at the end if hours is negative.