### PR TITLE
Remove the hackney dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Tzdata.Mixfile do
 
   def application do
     [
-      applications: [:hackney, :logger],
+      applications: [:logger],
       env: env,
       mod: {Tzdata.App, []}
     ]
@@ -21,7 +21,6 @@ defmodule Tzdata.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.0"},
       {:earmark, "~> 0.1.17", only: :dev},
       {:ex_doc, "~> 0.10", only: :dev},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{"earmark": {:hex, :earmark, "0.1.17"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "hackney": {:hex, :hackney, "1.3.2"},
   "idna": {:hex, :idna, "1.0.2"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}


### PR DESCRIPTION
The reasoning behind this change is that `hackney` is not really needed for doing basic HEAD and GET requests.