### PR TITLE
clean up syntax warnings

### DIFF
--- a/lib/tzdata.ex
+++ b/lib/tzdata.ex
@@ -200,9 +200,9 @@ defmodule Tzdata do
     {:ok, periods} = possible_periods_for_zone_and_time(zone_name, time_point)
     periods
     |> Enum.filter(fn x ->
-                     ((Map.get(x.from, time_type) |>smaller_than_or_equals time_point)
-                     && (Map.get(x.until, time_type) |>bigger_than time_point))
-                   end)
+      ((Map.get(x.from, time_type) |> smaller_than_or_equals(time_point)) &&
+      (Map.get(x.until, time_type) |> bigger_than(time_point)))
+    end)
   end
 
   # Use dynamic periods for points in time that are about 50 years into the future
@@ -230,7 +230,7 @@ defmodule Tzdata do
 
   ## Example
 
-      iex> Tzdata.leap_seconds_with_tai_diff |> Enum.take 3
+      iex> Tzdata.leap_seconds_with_tai_diff |> Enum.take(3)
       [%{date_time: {{1971, 12, 31}, {23, 59, 60}}, tai_diff: 10},
        %{date_time: {{1972,  6, 30}, {23, 59, 60}}, tai_diff: 11},
        %{date_time: {{1972, 12, 31}, {23, 59, 60}}, tai_diff: 12}]
@@ -240,7 +240,7 @@ defmodule Tzdata do
   end
 
   just_leap_seconds = leap_seconds_data[:leap_seconds]
-    |> Enum.map &(Map.get(&1, :date_time))
+    |> Enum.map(&(Map.get(&1, :date_time)))
   @doc """
   Get a list of known leap seconds. The leap seconds are datetime
   tuples representing the extra leap second to be inserted.
@@ -250,7 +250,7 @@ defmodule Tzdata do
 
   ## Example
 
-      iex> Tzdata.leap_seconds |> Enum.take 3
+      iex> Tzdata.leap_seconds |> Enum.take(3)
       [{{1971, 12, 31}, {23, 59, 60}},
        {{1972,  6, 30}, {23, 59, 60}},
        {{1972, 12, 31}, {23, 59, 60}}]

--- a/lib/tzdata/basic_data.ex
+++ b/lib/tzdata/basic_data.ex
@@ -29,6 +29,6 @@ defmodule Tzdata.BasicData do
   # Group by filename
   by_group = all_files_read
   |> Enum.map(fn {name, file_read} -> {name, Organizer.zone_and_link_list(file_read)} end)
-  |> Enum.into Map.new
+  |> Enum.into(Map.new)
   def zones_and_links_by_groups, do: unquote(Macro.escape(by_group))
 end

--- a/lib/tzdata/far_future_dynamic_periods.ex
+++ b/lib/tzdata/far_future_dynamic_periods.ex
@@ -47,10 +47,10 @@ defmodule Tzdata.FarFutureDynamicPeriods do
     end_rule = rules |> tl |> hd
     std_off = begin_rule.save
 
-    if length(prev_periods) >= rules_per_year do
-      until_time_year = year + 1
+    until_time_year = if length(prev_periods) >= rules_per_year do
+      year + 1
     else
-      until_time_year = year
+      year
     end
 
     from_standard_time = standard_time_from_utc(from, utc_off)
@@ -117,6 +117,6 @@ defmodule Tzdata.FarFutureDynamicPeriods do
     {:ok, rules} = BasicData.rules(rule_name)
     rules
     |> Util.rules_for_year(year)
-    |> Enum.sort &(&1.in < &2.in)
+    |> Enum.sort(&(&1.in < &2.in))
   end
 end

--- a/lib/tzdata/parser.ex
+++ b/lib/tzdata/parser.ex
@@ -141,7 +141,10 @@ defmodule Tzdata.Parser do
     format: captured["format"],
     until: until}
     # remove until key if it is nil
-    if (map[:until]==nil) do map = Map.delete(map,:until) end
-    map
+    if (map[:until]==nil) do
+      Map.delete(map,:until)
+    else
+      map
+    end
   end
 end

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -39,8 +39,11 @@ defmodule Tzdata.Util do
     # maybe the hours are negative, so use the absolute value in this calculation
     result = abs(hours)*3600+mins*60+secs
     # if hours are negative, the whole result should be negative: multiply by -1
-    if Regex.match?(~r/-/, hd(list)), do: result = -1*result
-    result
+    if Regex.match?(~r/-/, hd(list)) do
+      -1 * result
+    else
+      result
+    end
   end
 
   @doc """
@@ -277,7 +280,7 @@ defmodule Tzdata.Util do
   for the year.
   """
   def rules_for_year(rules, year) do
-    rules |> Enum.filter fn(rule) -> rule_applies_for_year(rule, year) end
+    rules |> Enum.filter(fn(rule) -> rule_applies_for_year(rule, year) end)
   end
 
   @doc """

--- a/test/table_data_test.exs
+++ b/test/table_data_test.exs
@@ -3,11 +3,11 @@ defmodule TableDataTest do
   alias Tzdata.TableData
 
   test "list of timezones" do
-    assert TableData.timezones |> Enum.member? "Europe/London"
+    assert TableData.timezones |> Enum.member?("Europe/London")
   end
 
   test "list of country codes" do
-    assert TableData.country_codes |> Enum.member? "UY"
+    assert TableData.country_codes |> Enum.member?("UY")
   end
 
   test "timezone entries for country code" do

--- a/test/tz_data_test.exs
+++ b/test/tz_data_test.exs
@@ -30,11 +30,11 @@ defmodule TzDataTest do
 
   test "Should provide list of zone names and link names" do
     # London is cononical zone. Jersey is a link
-    assert TzData.zone_list |> Enum.member? "Europe/London"
+    assert TzData.zone_list |> Enum.member?("Europe/London")
     assert TzData.zone_list |> Enum.member?("Europe/Jersey") != true
     assert TzData.link_list |> Enum.member?("Europe/London") != true
-    assert TzData.link_list |> Enum.member? "Europe/Jersey"
-    assert TzData.zone_and_link_list |> Enum.member? "Europe/London"
-    assert TzData.zone_and_link_list |> Enum.member? "Europe/Jersey"
+    assert TzData.link_list |> Enum.member?("Europe/Jersey")
+    assert TzData.zone_and_link_list |> Enum.member?("Europe/London")
+    assert TzData.zone_and_link_list |> Enum.member?("Europe/Jersey")
   end
 end

--- a/test/tzdata_test.exs
+++ b/test/tzdata_test.exs
@@ -4,21 +4,41 @@ defmodule TzdataTest do
 
   test "Get periods for point in time far away in the future. For all timezones." do
     # roughly 150 years from now
-    point_in_time = :calendar.universal_time |> :calendar.datetime_to_gregorian_seconds |> + (3600*24*365*150)
+    point_in_time = :calendar.universal_time
+    |> :calendar.datetime_to_gregorian_seconds
+    |> Kernel.+(3600*24*365*150)
+
     # This should not raise any exceptions
-    Tzdata.zone_list |> Enum.map &( Tzdata.periods_for_time(&1, point_in_time, :wall) )
+    Tzdata.zone_list
+    |> Enum.map(&( Tzdata.periods_for_time(&1, point_in_time, :wall) ))
   end
 
   test "time for going on DST should be the same in the far future for zones without changes" do
     zone_name = "Europe/Copenhagen" # This test must change if this zone changes
-    about_150_years_from_now = :calendar.universal_time |> :calendar.datetime_to_gregorian_seconds |> + (3600*24*365*150)
-    {{year, _month, _day}, time} = :calendar.gregorian_seconds_to_datetime(about_150_years_from_now)
-    feb_first_close = {{year-150, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds
-    feb_first_in_a_long_time = {{year, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds
-    p1 = Tzdata.periods_for_time(zone_name, feb_first_close, :wall) |> hd
-    p2 = Tzdata.periods_for_time(zone_name, feb_first_in_a_long_time, :wall) |> hd
-    {_p1_date, p1_time} = p1.from.wall |> :calendar.gregorian_seconds_to_datetime
-    {_p2_date, p2_time} = p2.from.wall |> :calendar.gregorian_seconds_to_datetime
+    about_150_years_from_now = :calendar.universal_time
+    |> :calendar.datetime_to_gregorian_seconds
+    |> Kernel.+(3600*24*365*150)
+
+    {{year, _month, _day}, time} =
+      :calendar.gregorian_seconds_to_datetime(about_150_years_from_now)
+    feb_first_close = {{year-150, 2, 1}, time}
+    |> :calendar.datetime_to_gregorian_seconds
+
+    feb_first_in_a_long_time = {{year, 2, 1}, time}
+    |> :calendar.datetime_to_gregorian_seconds
+
+    p1 = Tzdata.periods_for_time(zone_name, feb_first_close, :wall)
+    |> hd
+
+    p2 = Tzdata.periods_for_time(zone_name, feb_first_in_a_long_time, :wall)
+    |> hd
+
+    {_p1_date, p1_time} = p1.from.wall
+    |> :calendar.gregorian_seconds_to_datetime
+
+    {_p2_date, p2_time} = p2.from.wall
+    |> :calendar.gregorian_seconds_to_datetime
+
     assert p1_time == p2_time
   end
 end


### PR DESCRIPTION
Cleans up the syntax warnings on `0.1.x` / `pre_ets` versions of the library. Tested on Elixir 1.3. 