### PR TITLE
replace hackney with httpc from the erlang client library

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Tzdata.Mixfile do
 
   def application do
     [
-      applications: [:hackney, :logger],
+      applications: [:logger, :inets, :ssl],
       env: env(),
       mod: {Tzdata.App, []}
     ]
@@ -21,7 +21,6 @@ defmodule Tzdata.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.0"},
       {:earmark, "~> 0.1.17", only: :dev},
       {:ex_doc, "~> 0.10", only: :dev},
     ]


### PR DESCRIPTION
I was recently setting up a new project and noticed that hackney is a relatively expensive dependency for my project. I ❤️  the design decisions of automatically keeping the UTC data up-to-date automatically with an OTP application, but I wondered if I could get away without needing `hackney`, `certifi`, `idna`, `metrics`, `mimerl`, and `ssl_verify_fun`.

So i wrote this PR to broach the idea of using `httpc` from the erlang standard library for downloading the latest data from `iana.org`.

Is this something you've considered in the past? Is there another consideration for using `hackney` that I've missed?