### PR TITLE
Fix Elixir 1.5 warnings

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -31,7 +31,7 @@ defmodule Tzdata.DataLoader do
     |> Stream.filter(fn(string) -> Regex.match?(~r/Release/, string) end)
     |> Enum.take(100) # 100 lines should be more than enough to get the first Release line
     |> hd
-    |> String.rstrip
+    |> String.replace(~r/\s*$/, "")
     captured = Regex.named_captures( ~r/Release[\s]+(?<version>[^\s]+)[\s]+-[\s]+(?<timestamp>.+)/m, release_string)
     captured["version"]
   end

--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -48,7 +48,7 @@ defmodule Tzdata.EtsHolder do
 
   defp load_ets_table(release_name) do
     file_name = "#{release_dir()}/#{release_name}.ets"
-    {:ok, _table} = :ets.file2tab(String.to_char_list(file_name))
+    {:ok, _table} = :ets.file2tab(:erlang.binary_to_list(file_name))
   end
 
   defp create_current_release_ets_table do

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -23,7 +23,7 @@ defmodule Tzdata.Util do
   def string_amount_to_secs("0"), do: 0
   def string_amount_to_secs(string) do
     string
-    |> String.strip
+    |> String.replace(~r/\s/, "")
     |> String.split(":")
     |> _string_amount_to_secs
   end


### PR DESCRIPTION
Tried to fix the warnings while preserving compatibility with older Elixir versions so I didn't use the replacement methods suggested by Elixir 1.5 because they all were introduced in 1.3.