### PR TITLE
Fix issue with missing directories

### DIFF
--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -67,7 +67,7 @@ defmodule Tzdata.EtsHolder do
     end
   end
   defp make_sure_a_release_dir_exists do
-    File.mkdir(release_dir())
+    File.mkdir_p(release_dir())
   end
 
   defp newest_release_on_file do


### PR DESCRIPTION
This PR is to fix an issue with missing directories.

Assuming I have this in the config file:

```elixir
config :tzdata, :data_dir, "/opt/app/elixir_tzdata_data"
```

But `elixir_tzdata_data` does not exist for any reason (running the release on docker for instance), We get this error on startup:

```
 [info] Application tzdata exited: exited in: Tzdata.App.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:shutdown, {:failed_to_start_child, Tzdata.EtsHolder, {%File.Error{action: "list directory", path: "/opt/app/elixir_tzdata_data/release_ets", reason: :enoent}, [{File, :ls!, 1, [file: 'lib/file.ex', line: 1191]}, {Tzdata.EtsHolder, :release_files, 0, [file: 'lib/tzdata/ets_holder.ex', line: 80]}, {Tzdata.EtsHolder, :make_sure_a_release_is_on_file, 0, [file: 'lib/tzdata/ets_holder.ex', line: 65]}, {Tzdata.EtsHolder, :init, 1, [file: 'lib/tzdata/ets_holder.ex', line: 10]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 328]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}}}}
            (tzdata) lib/tzdata/tzdata_app.ex:15: Tzdata.App.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4
{"Kernel pid terminated",application_controller,"{application_start_failure,tzdata,{bad_return,{{'Elixir.Tzdata.App',start,[normal,[]]},{'EXIT',{{badmatch,{error,{shutdown,{failed_to_start_child,'Elixir.Tzdata.EtsHolder',{#{'__exception__' => true,'__struct__' => 'Elixir.File.Error',action => <<\"list directory\">>,path => <<\"/opt/app/elixir_tzdata_data/release_ets\">>,reason => enoent},[{'Elixir.File','ls!',1,[{file,\"lib/file.ex\"},{line,1191}]},{'Elixir.Tzdata.EtsHolder',release_files,0,[{file,\"lib/tzdata/ets_holder.ex\"},{line,80}]},{'Elixir.Tzdata.EtsHolder',make_sure_a_release_is_on_file,0,[{file,\"lib/tzdata/ets_holder.ex\"},{line,65}]},{'Elixir.Tzdata.EtsHolder',init,1,[{file,\"lib/tzdata/ets_holder.ex\"},{line,10}]},{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,328}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,247}]}]}}}}},[{'Elixir.Tzdata.App',start,2,[{file,\"lib/tzdata/tzdata_app.ex\"},{line,15}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,273}]}]}}}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,tzdata,{bad_return,{{'Elixir.Tzdata.App',start,[normal,[]]},{'EXIT',{{badmatch,{error,{shutdown,{failed_to_start_child,'Elixi
```

This PR is using `File.mkdir_p` to recursively create all missing directories