### PR TITLE
small performance updates

### DIFF
--- a/lib/tzdata.ex
+++ b/lib/tzdata.ex
@@ -166,9 +166,9 @@ defmodule Tzdata do
   """
   def periods_for_time(zone_name, time_point, time_type) do
     {:ok, periods} = possible_periods_for_zone_and_time(zone_name, time_point)
-    match_fn = fn %{from: %{^time_type => from}, until: %{^time_type => until}} ->
-      smaller_than_or_equals(from, time_point) &&
-        bigger_than(until, time_point)
+    match_fn = fn %{from: from, until: until} ->
+      smaller_than_or_equals(Map.get(from, time_type), time_point) &&
+        bigger_than(Map.get(until, time_type), time_point)
     end
     do_consecutive_matching(periods, match_fn, [], false)
   end

--- a/lib/tzdata.ex
+++ b/lib/tzdata.ex
@@ -225,7 +225,7 @@ defmodule Tzdata do
   """
   def leap_seconds_with_tai_diff do
     leap_seconds_data = Tzdata.ReleaseReader.leap_sec_data
-    leap_seconds_data[:leap_seconds]
+    leap_seconds_data.leap_seconds
   end
 
   @doc """
@@ -243,10 +243,9 @@ defmodule Tzdata do
        {{1972, 12, 31}, {23, 59, 60}}]
   """
   def leap_seconds do
-    leap_seconds_data = Tzdata.ReleaseReader.leap_sec_data
-    just_leap_seconds = leap_seconds_data[:leap_seconds]
-      |> Enum.map(&(Map.get(&1, :date_time)))
-    just_leap_seconds
+    for %{date_time: date_time} <- leap_seconds_with_tai_diff() do
+      date_time
+    end
   end
 
   @doc """
@@ -260,7 +259,7 @@ defmodule Tzdata do
   """
   def leap_second_data_valid_until do
     leap_seconds_data = Tzdata.ReleaseReader.leap_sec_data
-    leap_seconds_data[:valid_until]
+    leap_seconds_data.valid_until
   end
 
   defp smaller_than_or_equals(:min, _), do: true

--- a/lib/tzdata.ex
+++ b/lib/tzdata.ex
@@ -181,7 +181,7 @@ defmodule Tzdata do
   end
   defp do_consecutive_matching([], _fun, [], _did_last_match), do: []
   defp do_consecutive_matching([], _fun, matched, _did_last_match), do: matched
-  defp do_consecutive_matching(_list, _fun, matched, false) when length(matched) > 0 do
+  defp do_consecutive_matching(_list, _fun, matched, false) when matched != [] do
     # If there are matches and previous did not match then the matches are no
     # long consecutive. So we return the result.
     matched |> Enum.reverse

--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -62,7 +62,7 @@ defmodule Tzdata.EtsHolder do
 
   defp make_sure_a_release_is_on_file do
     make_sure_a_release_dir_exists()
-    if length(release_files()) == 0 do
+    if release_files() == [] do
       Tzdata.DataBuilder.load_and_save_table
     end
   end

--- a/lib/tzdata/leap_sec_parser.ex
+++ b/lib/tzdata/leap_sec_parser.ex
@@ -76,7 +76,7 @@ defmodule Tzdata.LeapSecParser do
 
   # We assume that the head of the list is the element with the expiry timestamp
   defp organize_into_map([expiry_element = %{expires_at: _} | tail]) do
-    %{valid_until: expiry_element[:expires_at],
+    %{valid_until: expiry_element.expires_at,
       leap_seconds: tail
      }
   end

--- a/lib/tzdata/parser_organizer.ex
+++ b/lib/tzdata/parser_organizer.ex
@@ -27,7 +27,7 @@ defmodule Tzdata.ParserOrganizer do
   end
   defp add_links_to_map(map, []), do: map
   defp add_links_to_map(map, [head|tail]) do
-    map = Map.put(map, head[:to], head[:from])
+    map = Map.put(map, head.to, head.from)
     add_links_to_map(map, tail)
   end
 
@@ -41,9 +41,9 @@ defmodule Tzdata.ParserOrganizer do
   defp add_rules_to_map(map, []), do: map
   defp add_rules_to_map(map, [rule|tail]) do
     # add rule to rule list
-    new_rule_list = map[rule[:name]] ++ [rule]
+    new_rule_list = map[rule.name] ++ [rule]
     # update map with new rule list for rule name
-    map = Map.put(map, rule[:name], new_rule_list)
+    map = Map.put(map, rule.name, new_rule_list)
     add_rules_to_map(map, tail)
   end
 
@@ -59,15 +59,15 @@ defmodule Tzdata.ParserOrganizer do
   end
 
   defp list_of_single_value_from_map_list(list, key), do: Enum.map(list, fn elem -> elem[key] end)
-  defp filter_for_record_type(list, record_type), do: Enum.filter(list, fn x -> (x[:record_type] == record_type) end)
+  defp filter_for_record_type(list, record_type), do: Enum.filter(list, fn x -> (x.record_type == record_type) end)
 
   # Takes a list of maps. Returns map with keys that are :name of
   # the map, and values being the map
   def map_with_name_key(from_initial_pass, record_type) do
     from_initial_pass
-    |> Enum.filter(fn x -> (x[:record_type] == record_type) end)
+    |> Enum.filter(fn x -> (x.record_type == record_type) end)
     # Build list of maps with zone name as key
-    |> Enum.map(fn x -> Map.put(%{}, x[:name], x) end)
+    |> Enum.map(fn x -> Map.put(%{}, x.name, x) end)
     # Merge all the maps together to one map with all the zones
     |> merge_maps_in_list
   end

--- a/lib/tzdata/period_builder.ex
+++ b/lib/tzdata/period_builder.ex
@@ -106,8 +106,7 @@ defmodule Tzdata.PeriodBuilder do
   # At the last zone line, which should last until "max".
   # An example of this is Asia/Tokyo where at the time this is written
   # the current period starts in 1951 and is still in effect.
-  def calc_rule_periods(_btz_data, zone_lines, from, utc_off, std_off, years, _, letter) when length(zone_lines)==1 and years ==[] do
-    zone_line = zone_lines|>hd
+  def calc_rule_periods(_btz_data, [zone_line], from, utc_off, std_off, [], _, letter) do
     from_standard_time = standard_time_from_utc(from, utc_off)
     from_wall_time = wall_time_from_utc(from, utc_off, std_off)
     period =
@@ -121,7 +120,7 @@ defmodule Tzdata.PeriodBuilder do
     [period]
   end
 
-  def calc_rule_periods(btz_data, [zone_line|zone_line_tl], from, utc_off, std_off, years, _, letter) when years==[] do
+  def calc_rule_periods(btz_data, [zone_line|zone_line_tl], from, utc_off, std_off, [], _, letter) do
     from_standard_time = standard_time_from_utc(from, utc_off)
     from_wall_time = wall_time_from_utc(from, utc_off, std_off)
     until_utc = datetime_to_utc(Map.get(zone_line, :until), utc_off, std_off)
@@ -143,7 +142,7 @@ defmodule Tzdata.PeriodBuilder do
   def calc_rule_periods(btz_data, zone_lines, from, utc_off, std_off, [years_hd|years_tl], zone_rules, letter) do
     rules_for_year = TzUtil.rules_for_year(zone_rules, years_hd) |> sort_rules_by_time
     # if there are no rules for the given year, continue with the remaining years
-    if length(rules_for_year) == 0 do
+    if rules_for_year == [] do
       calc_rule_periods(btz_data, zone_lines, from, utc_off, std_off, years_tl, zone_rules, letter)
     else
       calc_periods_for_year(btz_data, zone_lines, from, utc_off, std_off, [years_hd|years_tl], zone_rules, rules_for_year, letter)
@@ -172,15 +171,15 @@ defmodule Tzdata.PeriodBuilder do
                 until: %{standard: until_standard_time, wall: until_wall_time, utc: until_utc},
                 zone_abbr: TzUtil.period_abbrevation(zone_line.format, std_off, letter)
               }
-    # If there are more rules for the year, continue with those rules
-    if length(rules_tail) > 0 do
-      [period|
-       calc_periods_for_year(btz_data, [zone_line|zone_line_tl], until_utc, utc_off, rule.save, years, zone_rules, rules_tail, rule.letter)
-      ]
-    # Else continue with the next zone line
-    else
+    # If there are no more rules for the year, continue with the next zone line
+    if rules_tail == [] do
       [period |
        calc_rule_periods(btz_data, [zone_line|zone_line_tl], until_utc, utc_off, rule.save, years|>tl, zone_rules, rule.letter)
+      ]
+    # Else continue with those rules
+    else
+      [period|
+       calc_periods_for_year(btz_data, [zone_line|zone_line_tl], until_utc, utc_off, rule.save, years, zone_rules, rules_tail, rule.letter)
       ]
     end
   end

--- a/lib/tzdata/release_reader.ex
+++ b/lib/tzdata/release_reader.ex
@@ -35,9 +35,9 @@ defmodule Tzdata.ReleaseReader do
   end
 
   defp do_periods_for_zone(zone) do
-    periods = lookup_periods_for_zone(zone)
-    if length(periods) > 0 do
-      periods |> hd |> elem(1)
+    case lookup_periods_for_zone(zone) do
+      [{_, period} | _] -> period
+      _ -> nil
     end
   end
   defp lookup_periods_for_zone(zone) when is_binary(zone), do: simple_lookup(String.to_atom zone)

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -254,7 +254,7 @@ defmodule Tzdata.Util do
       false
   """
   def rule_applies_for_year(rule, year) do
-    rule_applies_for_year_h(rule[:from], rule[:to], year)
+    rule_applies_for_year_h(rule.from, rule.to, year)
   end
   defp rule_applies_for_year_h(rule_from, :only, year) do
     rule_from == year
@@ -288,9 +288,9 @@ defmodule Tzdata.Util do
   Returns the date and time of when the rule goes into effect.
   """
   def time_for_rule(rule, year) do
-    {time, modifier} = rule[:at]
-    month = rule[:in]
-    day = tz_day_to_int year, month, rule[:on]
+    {time, modifier} = rule.at
+    month = rule.in
+    day = tz_day_to_int year, month, rule.on
     {{{year, month, day}, time}, modifier}
   end
 

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -29,17 +29,20 @@ defmodule Tzdata.Util do
   end
   # If there is only one or two elements, add 00 minutes or 00 seconds
   # until we have a 3 element list
-  defp _string_amount_to_secs(list) when length(list) == 1 or length(list) == 2 do
-    list ++ ["00"] |> _string_amount_to_secs
+  defp _string_amount_to_secs([h]) do
+    _string_amount_to_secs([h, "0", "0"])
+  end
+  defp _string_amount_to_secs([h, m]) do
+    _string_amount_to_secs([h, m, "0"])
   end
   # maybe the hours are negative, so multiply the result by -1
-  defp _string_amount_to_secs([<<?- :: utf8>> <> hours | rest]) when length(rest) == 2 do
-    -1 * _string_amount_to_secs([hours | rest])
+  defp _string_amount_to_secs([<<?- :: utf8>> <> hours, m, s]) do
+    -1 * _string_amount_to_secs([hours, m, s])
   end
-  defp _string_amount_to_secs(list) when length(list) == 3 do
-    {hours, ""} = Integer.parse(hd(list))
-    {mins, ""} = Integer.parse(list|>Enum.at(1))
-    {secs, ""} = Integer.parse(list|>Enum.at(2))
+  defp _string_amount_to_secs([h, m, s]) do
+    {hours, ""} = Integer.parse(h)
+    {mins, ""} = Integer.parse(m)
+    {secs, ""} = Integer.parse(s)
     hours*3600+mins*60+secs
   end
 


### PR DESCRIPTION
Not particularly related to #31, but does speed up our usage ~10%.

* avoid using `length/1`
* use more pattern matching
* avoid using `Access`