### PR TITLE
Raise on all File operations when loading new data

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -12,7 +12,7 @@ defmodule Tzdata.DataLoader do
     content_length = byte_size(body)
     {:ok, last_modified} = last_modified_from_headers(headers)
     new_dir_name ="#{data_dir()}/tmp_downloads/#{content_length}_#{:random.uniform(100000000)}/"
-    File.mkdir_p(new_dir_name)
+    File.mkdir_p!(new_dir_name)
     target_filename = "#{new_dir_name}latest.tar.gz"
     File.write!(target_filename, body)
     extract(target_filename, new_dir_name)
@@ -23,7 +23,7 @@ defmodule Tzdata.DataLoader do
 
   defp extract(filename, target_dir) do
     :erl_tar.extract(filename, [:compressed, {:cwd, target_dir}])
-    File.rm(filename) # remove tar.gz file after extraction
+    File.rm!(filename) # remove tar.gz file after extraction
   end
 
   def release_version_for_dir(dir_name) do
@@ -103,7 +103,7 @@ defmodule Tzdata.DataLoader do
 
   def set_latest_remote_poll_date do
     {y, m, d} = current_date_utc()
-    File.write(remote_poll_file_name(), "#{y}-#{m}-#{d}")
+    File.write!(remote_poll_file_name(), "#{y}-#{m}-#{d}")
   end
   def latest_remote_poll_date do
     latest_remote_poll_file_exists?() |> do_latest_remote_poll_date


### PR DESCRIPTION
Hey there! There was recently a new tzdata update and we got some failures in our setup:
```
[error] GenServer :tzdata_release_updater terminating
 ** (File.Error) could not write to file "/opt/app/lib/tzdata-0.5.12/priv/tmp_downloads/335571_44358462/latest.tar.gz": no such file or directory
     (elixir) lib/file.ex:719: File.write!/3
     (tzdata) lib/tzdata/data_loader.ex:17: Tzdata.DataLoader.download_new/1
     (tzdata) lib/tzdata/data_builder.ex:9: Tzdata.DataBuilder.load_and_save_table/0
     (tzdata) lib/tzdata/release_updater.ex:41: Tzdata.ReleaseUpdater.poll_for_update/0
     (tzdata) lib/tzdata/release_updater.ex:17: Tzdata.ReleaseUpdater.handle_info/2
     (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
     (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
     (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
 Last message: :check_if_time_to_update
```

This doesn't have anything to do with your library but something on our side. I did notice that it should've failed earlier on `File.mkdir_p/1`, but it doesn't raise and the return value isn't pattern-matched.  This PR makes all file operations in `DataLoader` raise on fail which should maybe save the next person a little bit of time debugging since getting an `:eacces` says more than an `:enoent`.