### PR TITLE
change url for tz database

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -7,7 +7,7 @@ defmodule Tzdata.DataLoader do
   def download_new(url \\ @download_url) do
     Logger.debug("Tzdata downloading new data from #{url}")
     set_latest_remote_poll_date()
-    {:ok, 200, headers, client_ref} = :hackney.get(url, [], "", [])
+    {:ok, 200, headers, client_ref} = :hackney.get(url, [], "", [follow_redirect: true])
     {:ok, body} = :hackney.body(client_ref)
     content_length = byte_size(body)
     {:ok, last_modified} = last_modified_from_headers(headers)

--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -3,7 +3,7 @@ defmodule Tzdata.DataLoader do
   @compile :nowarn_deprecated_function
   # Can poll for newest version of tz data and can download
   # and extract it.
-  @download_url "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+  @download_url "https://data.iana.org/time-zones/tzdata-latest.tar.gz"
   def download_new(url \\ @download_url) do
     Logger.debug("Tzdata downloading new data from #{url}")
     set_latest_remote_poll_date()


### PR DESCRIPTION
This is crashing for everybody this morning since data_loader is not following redirects:
```
Application phoenix started on node 'node@localhost'
Application tzdata exited: exited in: Tzdata.App.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:shutdown, {:failed_to_start_child, Tzdata.EtsHolder, {{:badmatch, {:ok, 302, [{"Date", "Wed, 22 Nov 2017 06:13:39 GMT"}, {"X-Frame-Options", "SAMEORIGIN"}, {"Content-Security-Policy", "upgrade-insecure-requests"}, {"Location", "https://data.iana.org/time-zones/tzdata-latest.tar.gz"}, {"Cache-Control", "public, s-maxage=600, max-age=3600"}, {"Expires", "Wed, 22 Nov 2017 07:13:39 GMT"}, {"Content-Length", "0"}, {"content-type", "application/x-gzip"}, {"Server", "Apache"}, {"Strict-Transport-Security", "max-age=48211200; preload"}, {"X-Cache-Hits", "117"}, {"Connection", "keep-alive"}], #Reference<0.0.7.772>}}, [{Tzdata.DataLoader, :download_new, 1, [file: 'lib/tzdata/data_loader.ex', line: 10]}, {Tzdata.DataBuilder, :load_and_save_table, 0, [file: 'lib/tzdata/data_builder.ex', line: 9]}, {Tzdata.EtsHolder, :init, 1, [file: 'lib/tzdata/ets_holder.ex', line: 10]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 328]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}}}}
            (tzdata) lib/tzdata/tzdata_app.ex:15: Tzdata.App.start/2
            (kernel) application_master.erl:273: :application_master.start_it_old/4
```

The included change of url is the easiest way to address it, but I suggest making this a little bit less prone to errors by using hackneys 'follow redirects' option. 
