### PR TITLE
Copy release file from priv if no release file present

### DIFF
--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -347,4 +347,12 @@ defmodule Tzdata.Util do
       _          -> Application.app_dir(:tzdata, "priv")
     end
   end
+
+  def custom_data_dir_configured? do
+    case Application.fetch_env(:tzdata, :data_dir) do
+      {:ok, nil} -> false
+      {:ok, _dir} -> true
+      _          -> false
+    end
+  end
 end


### PR DESCRIPTION
When a custom data dir has been configured and there are no releases
already present, the app would crash. This commit copies the release
from priv to the custom data dir.

Should fix #48 