### PR TITLE
Fix a potential connection leak on tzdata update

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -79,6 +79,9 @@ defmodule Tzdata.DataLoader do
       {:ok, 200, _headers, client_ref} ->
         {:ok, body} = :hackney.body(client_ref)
         {:ok, byte_size(body)}
+      {:ok, _status, _headers, client_ref} ->
+        :hackney.skip_body(client_ref)
+        {:error, :did_not_get_ok_response}
 
       _ ->
         {:error, :did_not_get_ok_response}


### PR DESCRIPTION
This PR fixes a potential connection leak on `Tzdata.ReleaseUpdater.poll_for_update/1`.

In hackney_pool, connections won't be checked in until the response body was read or skipped by calling functions like `:hackney.body/1` or `:hackney.skip_body/1` (this is expected behavior as of https://github.com/benoitc/hackney/issues/160). 

Current implementation possibly cause the connection leak if `Tzdata.DataLoader.latest_file_size_by_get/1` (invoked by `Tzdata.ReleaseUpdater.poll_for_update/1`) returns the status code other than 200.

Tzdata uses `:default` pool of hackney for HTTP request, so other applications using `:default` pool can also be affected.

### Note
I suspected that #56 is maybe related this fix, since IANA will return `302` with "www.iana.org" (fixed by #51), and that is exactly the situation that connection leak will happen.