### PR TITLE
re copy the default data when we can not open the ets table

### DIFF
--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -56,7 +56,12 @@ defmodule Tzdata.EtsHolder do
 
   defp load_ets_table(release_name) do
     file_name = "#{release_dir()}/#{release_name}.ets"
-    {:ok, _table} = :ets.file2tab(:erlang.binary_to_list(file_name))
+    case :ets.file2tab(:erlang.binary_to_list(file_name)) do
+      {:ok, _table}  ->  :ok
+      {:error, _table} ->
+        File.rm(file_name)
+        copy_release_dir_from_priv()
+    end
   end
 
   defp create_current_release_ets_table do


### PR DESCRIPTION
Thanks for a great library.

While playing with a nerves system I encountered a crash that seemed to  imply that the ets table got corrupted. 
```
03:49:52.724 [info]  Application tzdata exited: exited in: Tzdata.App.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:shutdown, {:failed_to_start_child, Tzdata.EtsHolder, {{:badmatch, {:error, {:read_error, {:not_a_log_file, '/root/elixir_tzdata_data/release_ets/2018e.ets'}}}}, [{Tzdata.EtsHolder, :load_ets_table, 1, [file: 'lib/tzdata/ets_holder.ex', line: 59]}, {Tzdata.EtsHolder, :load_release, 0, [file: 'lib/tzdata/ets_holder.ex', line: 52]}, {Tzdata.EtsHolder, :init, 1, [file: 'lib/tzdata/ets_holder.ex', line: 14]}, {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 374]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 342]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}}}
            (tzdata) lib/tzdata/tzdata_app.ex:15: Tzdata.App.start/2
            (kernel) application_master.erl:277: :application_master.start_it_old/4
```
I think that in this case the offending file should be deleted and the files should be re-copied from `priv` to start over.  It would result in the time zone database reverting to an earlier version until the next update.
I'm not sure if the successful branch should return `{:ok, table}`  instead of just `:ok` or something else.