### PR TITLE
Use String.to_existing_atom instead of String.to_atom

### DIFF
--- a/lib/tzdata/release_reader.ex
+++ b/lib/tzdata/release_reader.ex
@@ -12,15 +12,19 @@ defmodule Tzdata.ReleaseReader do
   def leap_sec_data,          do: simple_lookup(:leap_sec_data) |> hd |> elem(1)
   def by_group,               do: simple_lookup(:by_group) |> hd |> elem(1)
   def modified_at,            do: simple_lookup(:modified_at) |> hd |> elem(1)
+
   defp simple_lookup(key) do
     :ets.lookup(current_release_from_table() |> table_name_for_release_name, key)
   end
+
   def zone(zone_name) do
     {:ok, zones()[zone_name]}
   end
+
   def rules_for_name(rules_name) do
     {:ok, rules()[rules_name]}
   end
+
   def periods_for_zone_or_link(zone) do
     if Enum.member?(zone_list(), zone) do
       {:ok, do_periods_for_zone(zone)}
@@ -38,23 +42,29 @@ defmodule Tzdata.ReleaseReader do
 
   defp do_periods_for_zone(zone) do
     case lookup_periods_for_zone(zone) do
-      periods when is_list(periods) -> periods
+      periods when is_list(periods) ->
+        periods
         |> Enum.sort_by(fn period -> elem(period, 1) |> delimiter_to_number() end)
-      _ -> nil
+
+      _ ->
+        nil
     end
   end
-  defp lookup_periods_for_zone(zone) when is_binary(zone), do: simple_lookup(String.to_atom zone)
+
+  defp lookup_periods_for_zone(zone) when is_binary(zone),
+    do: simple_lookup(String.to_existing_atom(zone))
+
   defp lookup_periods_for_zone(_), do: []
 
   @doc !"""
-  Hack which is useful for sorting periods. Delimiters can be integers representing
-  gregorian seconds or :min or :max. By converting :min and :max to integers, they are
-  easier to sort. It is assumed that the fake numbers they are converted to are far beyond
-  numbers used.
-  TODO: Instead of doing this, do the sorting before inserting. When reading from a bag the order
-  should be preserved.
-  """
-  @very_high_number_representing_gregorian_seconds 9315537984000
+       Hack which is useful for sorting periods. Delimiters can be integers representing
+       gregorian seconds or :min or :max. By converting :min and :max to integers, they are
+       easier to sort. It is assumed that the fake numbers they are converted to are far beyond
+       numbers used.
+       TODO: Instead of doing this, do the sorting before inserting. When reading from a bag the order
+       should be preserved.
+       """
+  @very_high_number_representing_gregorian_seconds 9_315_537_984_000
   @low_number_representing_before_year_0 -1
   def delimiter_to_number(:min), do: @low_number_representing_before_year_0
   def delimiter_to_number(:max), do: @very_high_number_representing_gregorian_seconds
@@ -65,22 +75,28 @@ defmodule Tzdata.ReleaseReader do
   end
 
   defp table_name_for_release_name(release_name) do
-    "tzdata_rel_#{release_name}" |> String.to_atom
+    "tzdata_rel_#{release_name}" |> String.to_atom()
   end
 
   def periods_for_zone_time_and_type(zone_name, time_point, time_type) do
-    case do_periods_for_zone_time_and_type(zone_name, time_point, time_type) do
-      {:ok, []} ->
-        # If nothing was found, it could be that the zone name is not canonical.
-        # E.g. "Europe/Jersey" which links to "Europe/London".
-        # So we try with a link
-        zone_name_to_use = links()[zone_name]
-        case zone_name_to_use do
-          nil -> {:ok, []}
-          _ -> do_periods_for_zone_time_and_type(zone_name_to_use, time_point, time_type)
-        end
-      {:ok, list} ->
-        {:ok, list}
+    try do
+      case do_periods_for_zone_time_and_type(zone_name, time_point, time_type) do
+        {:ok, []} ->
+          # If nothing was found, it could be that the zone name is not canonical.
+          # E.g. "Europe/Jersey" which links to "Europe/London".
+          # So we try with a link
+          zone_name_to_use = links()[zone_name]
+
+          case zone_name_to_use do
+            nil -> {:ok, []}
+            _ -> do_periods_for_zone_time_and_type(zone_name_to_use, time_point, time_type)
+          end
+
+        {:ok, list} ->
+          {:ok, list}
+      end
+    rescue
+      ArgumentError -> {:ok, []}
     end
   end
 
@@ -88,31 +104,43 @@ defmodule Tzdata.ReleaseReader do
   @max_possible_periods_for_utc 1
   def do_periods_for_zone_time_and_type(zone_name, time_point, :wall) do
     match_fun = [
-      {{String.to_atom(zone_name), :_, :"$1", :_, :_, :"$2", :_, :_, :_, :_},
+      {{String.to_existing_atom(zone_name), :_, :"$1", :_, :_, :"$2", :_, :_, :_, :_},
        [
          {:andalso, {:orelse, {:"=<", :"$1", time_point}, {:==, :"$1", :min}},
           {:orelse, {:>, :"$2", time_point}, {:==, :"$2", :max}}}
        ], [:"$_"]}
     ]
 
-    case :ets.select(current_release_from_table() |> table_name_for_release_name, match_fun, @max_possible_periods_for_wall_time) do
+    case :ets.select(
+           current_release_from_table() |> table_name_for_release_name,
+           match_fun,
+           @max_possible_periods_for_wall_time
+         ) do
       {ets_result, _} ->
         {:ok, ets_result}
+
       _ ->
         {:ok, []}
     end
   end
+
   def do_periods_for_zone_time_and_type(zone_name, time_point, :utc) do
     match_fun = [
-      {{String.to_atom(zone_name), :"$1", :_, :_, :"$2", :_, :_, :_, :_, :_},
+      {{String.to_existing_atom(zone_name), :"$1", :_, :_, :"$2", :_, :_, :_, :_, :_},
        [
          {:andalso, {:orelse, {:"=<", :"$1", time_point}, {:==, :"$1", :min}},
           {:orelse, {:>, :"$2", time_point}, {:==, :"$2", :max}}}
        ], [:"$_"]}
     ]
-    case  :ets.select(current_release_from_table() |> table_name_for_release_name, match_fun, @max_possible_periods_for_utc) do
+
+    case :ets.select(
+           current_release_from_table() |> table_name_for_release_name,
+           match_fun,
+           @max_possible_periods_for_utc
+         ) do
       {ets_result, _} ->
         {:ok, ets_result}
+
       _ ->
         {:ok, []}
     end

--- a/lib/tzdata/tzdata_app.ex
+++ b/lib/tzdata/tzdata_app.ex
@@ -14,6 +14,11 @@ defmodule Tzdata.App do
       {:ok, :disabled} -> children
     end
 
-    {:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)
+    {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+
+    # Make zone atoms exist so that when to_existing_atom is called, all of the zones exist
+    Tzdata.zone_list |> Enum.map(&(&1 |> String.to_atom))
+
+    {:ok, pid}
   end
 end

--- a/test/tzdata_test.exs
+++ b/test/tzdata_test.exs
@@ -57,7 +57,11 @@ defmodule TzdataTest do
   @moroccan_time_zones ["Africa/Casablanca", "Africa/El_Aaiun"]
   test "Get periods for point in time far away in the future. For all timezones." do
     # roughly 150 years from now
-    point_in_time = :calendar.universal_time |> :calendar.datetime_to_gregorian_seconds |> Kernel.+(3600*24*365*150)
+    point_in_time =
+      :calendar.universal_time()
+      |> :calendar.datetime_to_gregorian_seconds()
+      |> Kernel.+(3600 * 24 * 365 * 150)
+
     # This should not raise any exceptions
     Tzdata.zone_list
     |> Enum.reject(&(Enum.member?(@moroccan_time_zones, &1)))
@@ -72,18 +76,55 @@ defmodule TzdataTest do
     Tzdata.zone_list
     |> Enum.filter(&(Enum.member?(@moroccan_time_zones, &1)))
     |> Enum.map(fn(zone) -> Tzdata.periods_for_time(zone, point_in_time, :wall) end)
+    Tzdata.zone_list() |> Enum.map(&Tzdata.periods_for_time(&1, point_in_time, :wall))
   end
 
   test "time for going on DST should be the same in the far future for zones without changes" do
-    zone_name = "Europe/Copenhagen" # This test must change if this zone changes
-    about_150_years_from_now = :calendar.universal_time |> :calendar.datetime_to_gregorian_seconds |> Kernel.+(3600*24*365*150)
-    {{year, _month, _day}, time} = :calendar.gregorian_seconds_to_datetime(about_150_years_from_now)
-    feb_first_close = {{year-150, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds
-    feb_first_in_a_long_time = {{year, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds
+    # This test must change if this zone changes
+    zone_name = "Europe/Copenhagen"
+
+    about_150_years_from_now =
+      :calendar.universal_time()
+      |> :calendar.datetime_to_gregorian_seconds()
+      |> Kernel.+(3600 * 24 * 365 * 150)
+
+    {{year, _month, _day}, time} =
+      :calendar.gregorian_seconds_to_datetime(about_150_years_from_now)
+
+    feb_first_close = {{year - 150, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds()
+    feb_first_in_a_long_time = {{year, 2, 1}, time} |> :calendar.datetime_to_gregorian_seconds()
     p1 = Tzdata.periods_for_time(zone_name, feb_first_close, :wall) |> hd
     p2 = Tzdata.periods_for_time(zone_name, feb_first_in_a_long_time, :wall) |> hd
-    {_p1_date, p1_time} = p1.from.wall |> :calendar.gregorian_seconds_to_datetime
-    {_p2_date, p2_time} = p2.from.wall |> :calendar.gregorian_seconds_to_datetime
+    {_p1_date, p1_time} = p1.from.wall |> :calendar.gregorian_seconds_to_datetime()
+    {_p2_date, p2_time} = p2.from.wall |> :calendar.gregorian_seconds_to_datetime()
     assert p1_time == p2_time
+  end
+
+  test "non existing time zone" do
+    zone_name = "Foo/Bar"
+    gregorian_seconds = 63_555_753_600
+
+    assert Tzdata.periods_for_time(zone_name, gregorian_seconds, :utc) == []
+
+    assert Tzdata.periods_for_time(zone_name, gregorian_seconds, :wall) == []
+  end
+
+  test "test that atom count does not increase by ~1000 when doing query of 1000 zone names" do
+    gregorian_seconds = 63_555_753_600
+    atom_count_before = :erlang.system_info(:atom_count)
+    # create random strings that will be used for zone names and could be turned into atoms
+    time_zone_names =
+      0..1000
+      |> Enum.map(&"Fake/#{&1}-#{:crypto.rand_uniform(1, 9_999_999)}")
+
+    time_zone_names
+    |> Enum.map(&Tzdata.periods_for_time(&1, gregorian_seconds, :utc))
+
+    time_zone_names
+    |> Enum.map(&Tzdata.periods_for_time(&1, gregorian_seconds, :wall))
+
+    atom_count_after = :erlang.system_info(:atom_count)
+    atom_count_diff = atom_count_after - atom_count_before
+    assert atom_count_diff < 900
   end
 end


### PR DESCRIPTION
when looking up time zone names. To avoid user input of time zone names
increasing the number of atoms.