### PR TITLE
chore: Requires the hackney application in prod

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,15 +19,11 @@ defmodule Tzdata.Mixfile do
 
   def application do
     [
-      applications: applications(Mix.env()),
       extra_applications: [:logger],
       env: env(),
       mod: {Tzdata.App, []}
     ]
   end
-
-  defp applications(:dev), do: [:hackney]
-  defp applications(_), do: []
 
   defp deps do
     [


### PR DESCRIPTION
A change necessary because of: https://github.com/lau/tzdata/commit/ac50d19fe4510faf17c04d319cce18f44e94a400#diff-6023be6004fce4718dad3dafb576d258R34

We are seeing this error:

```
GenServer :tzdata_release_updater terminating
** (UndefinedFunctionError) function :hackney.head/4 is undefined (module :hackney is not available)
    :hackney.head("https://data.iana.org/time-zones/tzdata-latest.tar.gz", [], "", [])
    (tzdata) lib/tzdata/http_client/hackney.ex:17: Tzdata.HTTPClient.Hackney.head/3
    (tzdata) lib/tzdata/data_loader.ex:46: Tzdata.DataLoader.last_modified_of_latest_available/1
    (tzdata) lib/tzdata/release_updater.ex:81: Tzdata.ReleaseUpdater.loaded_tzdata_matches_remote_last_modified?/0
    (tzdata) lib/tzdata/release_updater.ex:42: Tzdata.ReleaseUpdater.poll_for_update/0
    (tzdata) lib/tzdata/release_updater.ex:19: Tzdata.ReleaseUpdater.handle_info/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
Last message: :check_if_time_to_update
State: []
```

Co-authored-by: Andrew Summers <oasummerso@gmail.com>