### PR TITLE
Fix: Stop crash on aplications with paths with utf8 characters

### DIFF
--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -60,7 +60,7 @@ defmodule Tzdata.EtsHolder do
 
   defp load_ets_table(release_name) do
     file_name = "#{release_dir()}/#{release_name}.v#{@file_version}.ets"
-    {:ok, _table} = :ets.file2tab(:erlang.binary_to_list(file_name))
+    {:ok, _table} = file_name |> String.to_charlist() |> :ets.file2tab()
   end
 
   defp create_current_release_ets_table do

--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -87,16 +87,11 @@ defmodule Tzdata.EtsHolder do
     make_sure_a_release_dir_exists()
 
     cond do
-      release_files() == [] and Util.custom_data_dir_configured?() ->
-        Logger.info(
-          "No tzdata release files found in custom data dir. Copying release file from tzdata priv dir."
-        )
-
+      release_files() == [] and Util.custom_data_dir_configured? ->
+        Logger.info("No tzdata release files found in custom data dir. Copying release file from tzdata priv dir.")
         copy_release_dir_from_priv()
-
-      release_files() == [] and not Util.custom_data_dir_configured?() ->
+      release_files() == [] and not Util.custom_data_dir_configured? ->
         Logger.error("No tzdata release files found!")
-
       true ->
         nil
     end
@@ -105,7 +100,6 @@ defmodule Tzdata.EtsHolder do
   defp copy_release_dir_from_priv() do
     custom_destination_dir = Tzdata.Util.data_dir() <> "/release_ets"
     priv_release_ets_dir = Application.app_dir(:tzdata, "priv") <> "/release_ets"
-
     priv_release_ets_dir
     |> release_files_for_dir
     |> Enum.each(fn file ->

--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -60,7 +60,17 @@ defmodule Tzdata.EtsHolder do
 
   defp load_ets_table(release_name) do
     file_name = "#{release_dir()}/#{release_name}.v#{@file_version}.ets"
-    {:ok, _table} = file_name |> String.to_charlist() |> :ets.file2tab()
+
+    file_name
+    |> String.to_charlist()
+    |> :ets.file2tab()
+    |> case do
+      {:ok, table} ->
+        {:ok, table}
+
+      _error ->
+        raise "Failed to load ets table from file at #{file_name}"
+    end
   end
 
   defp create_current_release_ets_table do
@@ -77,11 +87,16 @@ defmodule Tzdata.EtsHolder do
     make_sure_a_release_dir_exists()
 
     cond do
-      release_files() == [] and Util.custom_data_dir_configured? ->
-        Logger.info("No tzdata release files found in custom data dir. Copying release file from tzdata priv dir.")
+      release_files() == [] and Util.custom_data_dir_configured?() ->
+        Logger.info(
+          "No tzdata release files found in custom data dir. Copying release file from tzdata priv dir."
+        )
+
         copy_release_dir_from_priv()
-      release_files() == [] and not Util.custom_data_dir_configured? ->
+
+      release_files() == [] and not Util.custom_data_dir_configured?() ->
         Logger.error("No tzdata release files found!")
+
       true ->
         nil
     end
@@ -90,6 +105,7 @@ defmodule Tzdata.EtsHolder do
   defp copy_release_dir_from_priv() do
     custom_destination_dir = Tzdata.Util.data_dir() <> "/release_ets"
     priv_release_ets_dir = Application.app_dir(:tzdata, "priv") <> "/release_ets"
+
     priv_release_ets_dir
     |> release_files_for_dir
     |> Enum.each(fn file ->


### PR DESCRIPTION
If your application had a utf8 character in it, `:erlang.binary_to_list/1` would not translate it to the right list, resulting in a failure to find the file, resulting in a crash with a cryptic message.

This PR aims to fix that error and make the error message less cryptic if it ever fails again.