### PR TITLE
Fix Elixir 1.11 warning

### DIFF
--- a/lib/tzdata/time_zone_database.ex
+++ b/lib/tzdata/time_zone_database.ex
@@ -96,7 +96,7 @@ defmodule Tzdata.TimeZoneDatabase do
     %{
       utc_offset: old_period.utc_off,
       std_offset: old_period.std_off,
-      zone_abbr: old_period.zone_abbr(),
+      zone_abbr: old_period.zone_abbr,
       from_wall: old_period.from.wall |> old_limit_to_new,
       until_wall: old_period.until.wall |> old_limit_to_new
     }


### PR DESCRIPTION
In Elixir 1.11, it warning about incorrect usage of field:

	warning: incompatible types:

	    map() !~ atom()

	in expression:

	    # lib/tzdata/time_zone_database.ex:99
	    old_period.zone_abbr()

	where "old_period" was given the type map() (due to calling var.field) in:

	    # lib/tzdata/time_zone_database.ex:97
	    old_period.utc_off

	where "old_period" was given the type map() (due to calling var.field) in:

	    # lib/tzdata/time_zone_database.ex:98
	    old_period.std_off

	where "old_period" was given the type map() (due to calling var.field) in:

	    # lib/tzdata/time_zone_database.ex:98
	    old_period.std_off

	where "old_period" was given the type atom() (due to calling var.fun()) in:

	    # lib/tzdata/time_zone_database.ex:99
	    old_period.zone_abbr()

	HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()

	Conflict found at
	  lib/tzdata/time_zone_database.ex:99: Tzdata.TimeZoneDatabase.old_tz_period_to_new/1

Fixes by uses "old_period.zone_abbr" instead of "old_period.zone_abbr()".