### PR TITLE
Fix more elixir 1.11 compile warnings

### DIFF
--- a/lib/tzdata/ets_holder.ex
+++ b/lib/tzdata/ets_holder.ex
@@ -8,7 +8,7 @@ defmodule Tzdata.EtsHolder do
 
   @file_version 2
 
-  def start_link() do
+  def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/tzdata/parser.ex
+++ b/lib/tzdata/parser.ex
@@ -24,7 +24,7 @@ defmodule Tzdata.Parser do
       "Rule" -> [process_rule(head)|process_tz_list(tail)]
       "Link" -> [process_link(head)|process_tz_list(tail)]
       "Zone" -> process_zone([head|tail])
-      ______ -> [head|process_tz_list(tail)] # pass through
+      _      -> [head|process_tz_list(tail)] # pass through
     end
   end
 

--- a/lib/tzdata/release_updater.ex
+++ b/lib/tzdata/release_updater.ex
@@ -5,7 +5,7 @@ defmodule Tzdata.ReleaseUpdater do
   use GenServer
   alias Tzdata.DataLoader
 
-  def start_link() do
+  def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: :tzdata_release_updater)
   end
 

--- a/lib/tzdata/tzdata_app.ex
+++ b/lib/tzdata/tzdata_app.ex
@@ -4,13 +4,11 @@ defmodule Tzdata.App do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      worker(Tzdata.EtsHolder, [])
+      Tzdata.EtsHolder
     ]
     children = case Application.fetch_env(:tzdata, :autoupdate) do
-      {:ok, :enabled} -> children ++ [worker(Tzdata.ReleaseUpdater, [])]
+      {:ok, :enabled} -> children ++ [Tzdata.ReleaseUpdater]
       {:ok, :disabled} -> children
     end
 


### PR DESCRIPTION
When compile the project with elixir 1.11, we still get 2 warnins.

```
Compiling 4 files (.ex)
warning: unknown compiler variable "______" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)
  lib/tzdata/parser.ex:27: Tzdata.Parser.process_tz_list/1

warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
Found at 2 locations:
  lib/tzdata/tzdata_app.ex:10: Tzdata.App.start/2
  lib/tzdata/tzdata_app.ex:13: Tzdata.App.start/2
```

And by migrating `Supervisor.Spec.worker` to `Supervisor`, the code should not able to support Elixir prior than 1.5.0.