### PR TITLE
chore(Warnings): Replace random with rand module due to elixir deprec…

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -14,7 +14,7 @@ defmodule Tzdata.DataLoader do
     {:ok, last_modified} = last_modified_from_headers(headers)
 
     new_dir_name =
-      "#{data_dir()}/tmp_downloads/#{content_length}_#{:random.uniform(100_000_000)}/"
+      "#{data_dir()}/tmp_downloads/#{content_length}_#{:rand.uniform(100_000_000)}/"
 
     File.mkdir_p!(new_dir_name)
     target_filename = "#{new_dir_name}latest.tar.gz"


### PR DESCRIPTION
…ation warning

@lau `:rand.uniform/1` has been around since OTP 18.0 so this should be an easy replacement.

https://erlang.org/doc/man/rand.html#uniform-1