### PR TITLE
Use :rand module instead of :random

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -14,7 +14,7 @@ defmodule Tzdata.DataLoader do
     {:ok, last_modified} = last_modified_from_headers(headers)
 
     new_dir_name =
-      "#{data_dir()}/tmp_downloads/#{content_length}_#{:random.uniform(100_000_000)}/"
+      "#{data_dir()}/tmp_downloads/#{content_length}_#{:rand.uniform(100_000_000)}/"
 
     File.mkdir_p!(new_dir_name)
     target_filename = "#{new_dir_name}latest.tar.gz"


### PR DESCRIPTION
Fixes compilation warning below:

```
warning: :random.uniform/1 is deprecated. Use the 'rand' module instead
  lib/tzdata/data_loader.ex:17: Tzdata.DataLoader.download_new/1
```