### PR TITLE
Remove Erlang Deprecation Warning

### DIFF
--- a/lib/tzdata/data_loader.ex
+++ b/lib/tzdata/data_loader.ex
@@ -13,7 +13,7 @@ defmodule Tzdata.DataLoader do
     {:ok, last_modified} = last_modified_from_headers(headers)
 
     new_dir_name =
-      "#{data_dir()}/tmp_downloads/#{content_length}_#{:rand.uniform(100_000_000)}/"
+      "#{data_dir()}/tmp_downloads/#{content_length}_#{:erlang.phash2(make_ref())}/"
 
     File.mkdir_p!(new_dir_name)
     target_filename = "#{new_dir_name}latest.tar.gz"

--- a/test/tzdata_test.exs
+++ b/test/tzdata_test.exs
@@ -115,7 +115,7 @@ defmodule TzdataTest do
     # create random strings that will be used for zone names and could be turned into atoms
     time_zone_names =
       0..1000
-      |> Enum.map(&"Fake/#{&1}-#{:crypto.rand_uniform(1, 9_999_999)}")
+      |> Enum.map(&"Fake/#{&1}-#{:erlang.phash2(make_ref())}")
 
     time_zone_names
     |> Enum.map(&Tzdata.periods_for_time(&1, gregorian_seconds, :utc))


### PR DESCRIPTION
Utilizes `:erlang.phash2/1` to generate a number because that works with both old & new erlang versions.

```
warning: :random.uniform/1 is deprecated. Use the 'rand' module instead
  lib/tzdata/data_loader.ex:17: Tzdata.DataLoader.download_new/1
```