### PR TITLE
Adjust to different month format

### DIFF
--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -152,9 +152,14 @@ defmodule Tzdata.Util do
   def weekday_string_to_number!(parm), do: parm
 
   def month_number_for_month_name(string) do
-    string
-    |> String.downcase()
-    |> cap_month_number_for_month_name
+    if string =~ ~r/^\d+$/ do
+      to_int(string)
+    else
+      string
+      |> String.downcase()
+      |> String.slice(0..2)
+      |> cap_month_number_for_month_name()
+    end
   end
 
   defp cap_month_number_for_month_name("jan"), do: 1
@@ -169,7 +174,7 @@ defmodule Tzdata.Util do
   defp cap_month_number_for_month_name("oct"), do: 10
   defp cap_month_number_for_month_name("nov"), do: 11
   defp cap_month_number_for_month_name("dec"), do: 12
-  defp cap_month_number_for_month_name(string), do: to_int(string)
+  defp cap_month_number_for_month_name(other), do: {:error, {:bad_month, other}}
 
   @doc false &&
          """

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,6 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
Fixes #143 

This has been tested on a production application:

```
Tzdata has updated the release from 2024a to 2024b
```

I also updated the `ssl_verify_fun` dependency, because the original version wouldn't compile. The newest version has a fix that allows it to compile.