### PR TITLE
PST timezone is missing

### DIFF
--- a/test/tz_time_zone_database_test.exs
+++ b/test/tz_time_zone_database_test.exs
@@ -107,5 +107,11 @@ defmodule Tzdata.TimeZoneDatabaseTest do
                ~N[2019-01-01 10:59:59],
                "Pacific/Norfolk"
              )
+
+    assert {:error, :time_zone_not_found} ==
+             TimeZoneDatabase.time_zone_periods_from_wall_datetime(
+               ~N[2022-11-10 10:59:59],
+               "PST"
+             )
   end
 end


### PR DESCRIPTION
PST is showing up as an unknown timezone.
CST is also missing. EST and MST work as expected.

This PR doesn't actually fix the issue, just demonstrates it as part of issue #152