### PR TITLE
Fix Elixir compiler warnings for decreasing ranges without explicit steps

### DIFF
--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -64,7 +64,7 @@ defmodule Tzdata.Util do
   def last_weekday_of_month(year, month, weekday) do
     weekday = weekday_string_to_number!(weekday)
     days_in_month = day_count_for_month(year, month)
-    day_list = Enum.to_list(days_in_month..1)
+    day_list = Enum.to_list(days_in_month..1//-1)
     {:ok, day} = first_matching_weekday_in_month(year, month, weekday, day_list)
     day
   end
@@ -96,7 +96,7 @@ defmodule Tzdata.Util do
   # Can be in the previous month if no matching date and weekday is found in the specified month
   defp first_weekday_of_month_at_most(year, month, weekday, maximum_date) do
     weekday = weekday_string_to_number!(weekday)
-    day_list = Enum.to_list(maximum_date..1)
+    day_list = Enum.to_list(maximum_date..1//-1)
 
     case first_matching_weekday_in_month(year, month, weekday, day_list) do
       {:ok, day} when is_integer(day) ->

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -1,6 +1,8 @@
 defmodule Tzdata.Util do
   @moduledoc false
 
+  @elixir_newer_1_12 Version.match?(System.version(), ">= 1.12.0")
+
   @doc """
     Take strings of amounts and convert them to ints of seconds.
     For instance useful for strings from TZ gmt offsets.
@@ -64,7 +66,7 @@ defmodule Tzdata.Util do
   def last_weekday_of_month(year, month, weekday) do
     weekday = weekday_string_to_number!(weekday)
     days_in_month = day_count_for_month(year, month)
-    day_list = Enum.to_list(days_in_month..1//-1)
+    day_list = Enum.to_list(decreasing_range(days_in_month, 1))
     {:ok, day} = first_matching_weekday_in_month(year, month, weekday, day_list)
     day
   end
@@ -96,7 +98,7 @@ defmodule Tzdata.Util do
   # Can be in the previous month if no matching date and weekday is found in the specified month
   defp first_weekday_of_month_at_most(year, month, weekday, maximum_date) do
     weekday = weekday_string_to_number!(weekday)
-    day_list = Enum.to_list(maximum_date..1//-1)
+    day_list = Enum.to_list(decreasing_range(maximum_date, 1))
 
     case first_matching_weekday_in_month(year, month, weekday, day_list) do
       {:ok, day} when is_integer(day) ->
@@ -563,6 +565,21 @@ defmodule Tzdata.Util do
       {:ok, nil} -> false
       {:ok, _dir} -> true
       _ -> false
+    end
+  end
+
+  if @elixir_newer_1_12 do
+    # See PR #154.
+    # Elixir 1.17 and 1.18 deprecated using decreasing Ranges without explicit steps.
+    # On the other hand, older elixir versions, before 1.12, don't know the `first..last//-1` syntax.
+    # As long as we want to support those versions, we need to compile conditionally.
+
+    defp decreasing_range(upper, lower) when upper >= lower do
+      upper..lower//-1
+    end
+  else
+    defp decreasing_range(upper, lower) when upper >= lower do
+      upper..lower
     end
   end
 end


### PR DESCRIPTION
# Issue
Elixir 1.17 and 1.18 deprecated using decreasing Ranges without explicit steps.

See https://hexdocs.pm/elixir/1.17/changelog.html#4-hard-deprecations:
> * [Range] `left..right` without explicit steps inside patterns and guards is deprecated, write `left..right//step` instead
> * [Range] Decreasing ranges, such as `10..1` without an explicit step is deprecated, write `10..1//-1` instead

And https://hexdocs.pm/elixir/1.18/changelog.html#4-hard-deprecations:
> * [Range] Deprecate inferring negative ranges on `Range.new/2`

Using implicit decreasing Ranges gives warnings like these:
```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (tzdata 1.1.2) lib/tzdata/util.ex:67: Tzdata.Util.last_weekday_of_month/3
  (tzdata 1.1.2) lib/tzdata/util.ex:203: Tzdata.Util.tz_day_to_date/3
  (tzdata 1.1.2) lib/tzdata/util.ex:445: Tzdata.Util.time_for_rule/2
  (tzdata 1.1.2) lib/tzdata/far_future_dynamic_periods.ex:89: Tzdata.FarFutureDynamicPeriods.first_period_that_ends_in_year/2
  (tzdata 1.1.2) lib/tzdata/far_future_dynamic_periods.ex:27: Tzdata.FarFutureDynamicPeriods.periods_for_point_in_time/2
  (tzdata 1.1.2) lib/tzdata.ex:196: Tzdata.periods_for_time/3
  (tzdata 1.1.2) lib/tzdata/time_zone_database.ex:32: Tzdata.TimeZoneDatabase.time_zone_periods_from_wall_datetime/2
  (elixir 1.18.1) lib/calendar/datetime.ex:569: DateTime.from_naive/3
  (elixir 1.18.1) lib/calendar/datetime.ex:685: DateTime.from_naive!/3
```

# Resolution
Use explicit `//-1` step for decreasing Ranges.