### PR TITLE
chore(Elixir): Fix warnings emitted by elixir 1.18

### DIFF
--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -64,7 +64,7 @@ defmodule Tzdata.Util do
   def last_weekday_of_month(year, month, weekday) do
     weekday = weekday_string_to_number!(weekday)
     days_in_month = day_count_for_month(year, month)
-    day_list = Enum.to_list(days_in_month..1)
+    day_list = Enum.to_list(days_in_month..1//-1)
     {:ok, day} = first_matching_weekday_in_month(year, month, weekday, day_list)
     day
   end
@@ -96,7 +96,7 @@ defmodule Tzdata.Util do
   # Can be in the previous month if no matching date and weekday is found in the specified month
   defp first_weekday_of_month_at_most(year, month, weekday, maximum_date) do
     weekday = weekday_string_to_number!(weekday)
-    day_list = Enum.to_list(maximum_date..1)
+    day_list = Enum.to_list(maximum_date..1//-1)
 
     case first_matching_weekday_in_month(year, month, weekday, day_list) do
       {:ok, day} when is_integer(day) ->


### PR DESCRIPTION
This PR fixes two warnings that were added by 1.18:

```warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (tzdata 1.1.2) lib/tzdata/util.ex:67: Tzdata.Util.last_weekday_of_month/3
  (tzdata 1.1.2) lib/tzdata/util.ex:203: Tzdata.Util.tz_day_to_date/3
  (tzdata 1.1.2) lib/tzdata/util.ex:268: Tzdata.Util.transform_until_datetime/2
  (tzdata 1.1.2) lib/tzdata/parser.ex:138: Tzdata.Parser.captured_zone_map_clean_up/1
  (tzdata 1.1.2) lib/tzdata/parser.ex:77: Tzdata.Parser.process_zone/5
  (tzdata 1.1.2) lib/tzdata/parser.ex:24: Tzdata.Parser.process_tz_list/1
  (tzdata 1.1.2) lib/tzdata/parser.ex:86: Tzdata.Parser.process_zone/5
  (tzdata 1.1.2) lib/tzdata/parser.ex:24: Tzdata.Parser.process_tz_list/1
  (tzdata 1.1.2) lib/tzdata/basic_data_map.ex:8: anonymous fn/2 in Tzdata.BasicDataMap.from_files_in_dir/1
  (elixir 1.18.2) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.18.2) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (tzdata 1.1.2) lib/tzdata/basic_data_map.ex:8: Tzdata.BasicDataMap.from_files_in_dir/1
  test/basic_data_map_test.exs:12: BasicDataMapTest."test Existing zone"/1
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
  (stdlib 6.2) timer.erl:595: :timer.tc/2
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:433: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```

```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (tzdata 1.1.2) lib/tzdata/util.ex:99: Tzdata.Util.first_weekday_of_month_at_most/4
  test/tz_util_test.exs:54: UtilTest."test tz_day_to_date"/1
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
  (stdlib 6.2) timer.erl:595: :timer.tc/2
  (ex_unit 1.18.2) lib/ex_unit/runner.ex:433: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```