### PR TITLE
Update doctest for tzdata 2025a release (fix the build)

### DIFF
--- a/lib/tzdata.ex
+++ b/lib/tzdata.ex
@@ -133,7 +133,7 @@ defmodule Tzdata do
 
       iex> Tzdata.periods("Europe/Madrid") |> elem(1) |> Enum.take(1)
       [%{from: %{standard: :min, utc: :min, wall: :min}, std_off: 0,
-        until: %{standard: 59989763760, utc: 59989764644, wall: 59989763760},
+        until: %{standard: 59989765516, utc: 59989766400, wall: 59989765516},
         utc_off: -884, zone_abbr: "LMT"}]
       iex> Tzdata.periods("Not existing")
       {:error, :not_found}


### PR DESCRIPTION
The doctest for Tzdata.periods/1 had hardcoded timezone data values from the 2024b release. When the library was upgraded to 2025a, the historical LMT data for Europe/Madrid was refined, causing the test to fail. Updated the doctest to reflect the correct values from the 2025a release.

This gets the tests back to green.

**Licensing**: *This contribution is made by employees of Mechanical Orchard, Inc. under the terms of the project's license.*