### PR TITLE
Fix :calendar crash on OTP 29 for IANA "24:00" transition times (fixes #166)

### DIFF
--- a/lib/tzdata/period_builder.ex
+++ b/lib/tzdata/period_builder.ex
@@ -370,15 +370,15 @@ defmodule Tzdata.PeriodBuilder do
   end
 
   def datetime_to_utc({datetime, modifier}, _, _) when modifier == :utc do
-    :calendar.datetime_to_gregorian_seconds(datetime)
+    TzUtil.datetime_to_gregorian_seconds(datetime)
   end
 
   def datetime_to_utc({datetime, modifier}, utc_off, _) when modifier == :standard do
-    :calendar.datetime_to_gregorian_seconds(datetime) - utc_off
+    TzUtil.datetime_to_gregorian_seconds(datetime) - utc_off
   end
 
   def datetime_to_utc({datetime, modifier}, utc_off, std_off) when modifier == :wall do
-    :calendar.datetime_to_gregorian_seconds(datetime) - utc_off - std_off
+    TzUtil.datetime_to_gregorian_seconds(datetime) - utc_off - std_off
   end
 
   def standard_time_from_utc(:min, _), do: :min

--- a/lib/tzdata/util.ex
+++ b/lib/tzdata/util.ex
@@ -450,19 +450,32 @@ defmodule Tzdata.Util do
 
   @doc "Converts a datetime and a type (:utc | :standard | wall) to a number of gregorian seconds"
   def datetime_to_utc({datetime, :utc}, _, _) when is_tuple(datetime) do
-    :calendar.datetime_to_gregorian_seconds(datetime)
+    datetime_to_gregorian_seconds(datetime)
   end
 
   def datetime_to_utc({datetime, :standard}, utc_off, _) when is_tuple(datetime) do
-    :calendar.datetime_to_gregorian_seconds(datetime) - utc_off
+    datetime_to_gregorian_seconds(datetime) - utc_off
   end
 
   def datetime_to_utc({datetime, :wall}, utc_off, std_off) when is_tuple(datetime) do
-    :calendar.datetime_to_gregorian_seconds(datetime) - utc_off - std_off
+    datetime_to_gregorian_seconds(datetime) - utc_off - std_off
   end
 
   def datetime_to_utc(datetime, _, _) when datetime in [:min, :max] do
     datetime
+  end
+
+  @doc """
+  Like `:calendar.datetime_to_gregorian_seconds/1`, but tolerant of the
+  end-of-day "24:00" times the IANA tz database uses for transition boundaries
+  (e.g. `{{2024, 3, 31}, {24, 0, 0}}`). Erlang/OTP 29 tightened
+  `:calendar.time_to_seconds/1` to reject hours outside 0..23, which would
+  otherwise crash period building for any zone whose rules use 24:00. Computing
+  the value directly treats 24:00 as the equivalent next-day 00:00 and matches
+  the result produced by OTP 28 and earlier.
+  """
+  def datetime_to_gregorian_seconds({date, {hour, minute, second}}) do
+    :calendar.date_to_gregorian_days(date) * 86_400 + hour * 3600 + minute * 60 + second
   end
 
   @doc """

--- a/test/tz_util_test.exs
+++ b/test/tz_util_test.exs
@@ -47,6 +47,23 @@ defmodule UtilTest do
     assert TzUtil.time_for_rule(rule, 1917) == {{{1917, 10, 21}, {1,0,0}}, :wall}
   end
 
+  test "datetime_to_utc handles end-of-day 24:00 transition times" do
+    # The IANA tz database legally uses "24:00" for end-of-day transition
+    # boundaries, which transform_until_datetime/time_for_rule parse to an
+    # hour-24 tuple (e.g. {{2024, 3, 31}, {24, 0, 0}}). Erlang/OTP 29 tightened
+    # :calendar to reject hours outside 0..23, so converting these must treat
+    # 24:00 as the equivalent next-day 00:00 rather than crash.
+    next_day_midnight = :calendar.datetime_to_gregorian_seconds({{2024, 4, 1}, {0, 0, 0}})
+
+    assert TzUtil.datetime_to_utc({{{2024, 3, 31}, {24, 0, 0}}, :utc}, 0, 0) == next_day_midnight
+
+    assert TzUtil.datetime_to_utc({{{2024, 3, 31}, {24, 0, 0}}, :standard}, 3600, 0) ==
+             next_day_midnight - 3600
+
+    assert TzUtil.datetime_to_utc({{{2024, 3, 31}, {24, 0, 0}}, :wall}, 3600, 3600) ==
+             next_day_midnight - 3600 - 3600
+  end
+
   test "tz_day_to_date" do
     assert TzUtil.tz_day_to_date(2000, 4, "lastSun") == {2000, 4, 30}
     assert TzUtil.tz_day_to_date(1932, 4, "Sun>=25") == {1932, 5, 1}


### PR DESCRIPTION
Fixes #166.

## Problem
Erlang/OTP 29 tightened `:calendar.time_to_seconds/1` to reject hours outside `0..23`. The IANA tz database legally uses **"24:00"** for end-of-day transition boundaries, which `Tzdata.Util.time_for_rule/2` parses into an hour-24 datetime (e.g. `{{Y, M, D}, {24, 0, 0}}`).

`Tzdata.PeriodBuilder.datetime_to_utc/3` and `Tzdata.Util.datetime_to_utc/3` pass that datetime to `:calendar.datetime_to_gregorian_seconds/1` (which calls `time_to_seconds/1` internally), so on OTP 29 the `:tzdata_release_updater` crashes during period building (as reported in #166):

```
** (FunctionClauseError) no function clause matching in :calendar.time_to_seconds/1
   (stdlib 8.0) calendar.erl:873: :calendar.time_to_seconds({24, 0, 0})
   (stdlib 8.0) calendar.erl:275: :calendar.datetime_to_gregorian_seconds/1
   (tzdata 1.1.3) lib/tzdata/period_builder.ex:381: Tzdata.PeriodBuilder.datetime_to_utc/3
```

OTP ≤ 28 accepted `{24, 0, 0}` and returned the value for the equivalent next-day `00:00`, so this only surfaces after upgrading to OTP 29.

## Fix
Add `Tzdata.Util.datetime_to_gregorian_seconds/1`, which computes the value directly:

```elixir
:calendar.date_to_gregorian_days(date) * 86_400 + hour * 3600 + minute * 60 + second
```

This handles any hour (including 24) and is numerically identical to `:calendar.datetime_to_gregorian_seconds/1` for hours 0–23 — `24:00:00` on day D ≡ `00:00:00` on day D+1. Both `datetime_to_utc/3` implementations route through it.

## Tests
- Added a regression test in `test/tz_util_test.exs` covering `:utc` / `:standard` / `:wall` modifiers with a `24:00` datetime.
- Full suite green on **OTP 29.0.1 / Elixir 1.20.0** and **OTP 28.5 / Elixir 1.19.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
