### PR TITLE
Allow both hackney 1.x and 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Tzdata
 
+### Changed
+
+- Now supports version 4.x of hackney as well as 1.x
+
 ## [1.1.4] - 2026-06-22
 
 ### Fixed

--- a/lib/tzdata/http_client/hackney.ex
+++ b/lib/tzdata/http_client/hackney.ex
@@ -6,10 +6,19 @@ defmodule Tzdata.HTTPClient.Hackney do
   if Code.ensure_loaded?(:hackney) do
     @impl true
     def get(url, headers, options) do
-      with {:ok, status, headers, client_ref} <- :hackney.get(url, headers, "", options),
-           {:ok, body} <- :hackney.body(client_ref) do
+      with {:ok, status, headers, result} <- :hackney.get(url, headers, "", options),
+           {:ok, body} <- get_body(result) do
         {:ok, {status, headers, body}}
       end
+    end
+
+    defp get_body(result) when is_binary(result) do
+      # Hackney 4.x returns the body as a binary in the result from :hackney.get
+      {:ok, result}
+    end
+    defp get_body(client_ref) do
+      # Hackney 1.x returns a client_ref that we can fetch the body from
+      :hackney.body(client_ref)
     end
 
     @impl true
@@ -28,7 +37,7 @@ defmodule Tzdata.HTTPClient.Hackney do
     In order to use the built-in adapter based on Hackney HTTP client, add the
     following to your mix.exs dependencies list:
 
-        {:hackney, "~> 1.0"}
+        {:hackney, "~> 4.0"}
 
     See README for more information.
     """

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Tzdata.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.17"},
+      {:hackney, "~> 1.17 or ~> 4.0"},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
Let's allow both old and new hackney versions in order to make the transition easier for downstream projects.

Closes #155.

---
This is an alternative to #168.